### PR TITLE
Handle multiples frames inflight

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 add_library(kickcat src/Bus.cc
                     src/CoE.cc
                     src/Frame.cc
+                    src/Link.cc
                     src/LinuxSocket.cc
                     src/Mailbox.cc
                     src/protocol.cc
@@ -47,7 +48,7 @@ if (${CODE_COVERAGE})
   append_coverage_compiler_flags()
   set(GCOVR_ADDITIONAL_ARGS "--exclude-unreachable-branches")
   setup_target_for_coverage_gcovr_html(
-      NAME coverage  
+      NAME coverage
       EXECUTABLE unit
       EXCLUDE "unit/*" ".*gtest.*" "example" ".*gmock.*"
       )

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,6 +1,15 @@
 add_executable(test test.cc)
+add_executable(yolo yolo.cc)
 target_link_libraries(test kickcat)
+target_link_libraries(yolo kickcat)
 set_target_properties(test PROPERTIES
+    CXX_STANDARD 17
+    CXX_STANDARD_REQUIRED YES
+    CXX_EXTENSIONS NO
+    POSITION_INDEPENDENT_CODE ON
+)
+
+set_target_properties(yolo PROPERTIES
     CXX_STANDARD 17
     CXX_STANDARD_REQUIRED YES
     CXX_EXTENSIONS NO

--- a/include/AbstractSocket.h
+++ b/include/AbstractSocket.h
@@ -20,6 +20,9 @@ namespace kickcat
         virtual void close() noexcept = 0;
         virtual int32_t read(uint8_t* frame, int32_t frame_size) = 0;
         virtual int32_t write(uint8_t const* frame, int32_t frame_size) = 0;
+
+        int read_counter{0};
+        int write_counter{0};
     };
 }
 

--- a/include/Error.h
+++ b/include/Error.h
@@ -13,6 +13,14 @@ namespace kickcat
     #define THROW_ERROR_CODE(msg, code) (throw ErrorCode{LOCATION ": " msg, static_cast<int32_t>(code)})
     #define THROW_SYSTEM_ERROR(msg)     (throw std::system_error(errno, std::generic_category(), LOCATION ": " msg))
 
+#define DEBUG 1
+#ifdef DEBUG
+    #define DEBUG_PRINT(fmt, ...) fprintf(stderr, "DEBUG: %s:%d:%s(): " fmt, \
+        __FILE__, __LINE__, __func__, ##__VA_ARGS__)
+#else
+    #define DEBUG_PRINT(fmt, ...)
+#endif
+
     struct Error : public std::exception
     {
         Error(char const* message)

--- a/include/Link.h
+++ b/include/Link.h
@@ -1,0 +1,51 @@
+#ifndef KICKCAT_LINK_H
+#define KICKCAT_LINK_H
+
+#include <array>
+#include <memory>
+#include <functional>
+
+#include "Frame.h"
+
+namespace kickcat
+{
+    class AbstractSocket;
+
+    /// \brief Handle link layer
+    /// \details This class is responsible to handle frames on the link layers:
+    ///           - associate an id to each written frame to let the client fetch it later without knowning write/read ordering
+    ///           - handle link redundancy (TODO)
+    class Link
+    {
+    public:
+        Link(std::shared_ptr<AbstractSocket> socket);
+        ~Link();
+
+        // write a frame on the line and record the associated callbacks for later usage
+        void addFrame(Frame& frame, std::function<bool(Frame&)>& callback, std::function<void()> const& errorCallback);
+
+        /// process all waiting tasks
+        /// \details do N read on the line with N the number of addFrame() call.
+        ///          For each read frame, it will run the associated callback. If it fail, it will run the error callback.
+        void processFrames();
+
+        /// \brief helper for trivial access (i.e. most of the init bus frames)
+        void writeThenRead(Frame& frame);
+
+    private:
+        std::shared_ptr<AbstractSocket> socket_;
+        uint8_t index_{0};
+
+        struct callbacks
+        {
+            bool was_run{false};
+            std::function<bool(Frame&)> process;
+            std::function<void()> error;
+        };
+
+        // 256 -> index is an uint8_t
+        std::array<callbacks, 256> callbacks_{};
+    };
+}
+
+#endif

--- a/include/Slave.h
+++ b/include/Slave.h
@@ -43,7 +43,7 @@ namespace kickcat
             std::vector<eeprom::PDOEntry const*> TxPDO;
 
         };
-        SII sii;
+        SII sii{};
 
         struct PIMapping
         {

--- a/src/Link.cc
+++ b/src/Link.cc
@@ -1,0 +1,75 @@
+#include "Link.h"
+#include "AbstractSocket.h"
+#include "Time.h"
+#include <iostream> //debug, to remove
+
+namespace kickcat
+{
+    Link::Link(std::shared_ptr<AbstractSocket> socket)
+        : socket_(socket)
+    {
+
+    }
+
+    Link::~Link()
+    {
+        socket_->close();
+    }
+
+    void Link::addFrame(Frame& frame, std::function<bool(Frame&)>& process, std::function<void()> const& error)
+    {
+        if (index_ == 255)
+        {
+            THROW_ERROR("Too many frame in flight. Max is 256");
+        }
+        callbacks_[index_].process = process;
+        callbacks_[index_].error = error;
+
+        frame.setIndex(index_);
+        frame.write(socket_);
+        ++index_;
+    }
+
+    // read the frame associated with the id 'frame_id'
+    void Link::processFrames()
+    {
+        uint8_t waiting_frame = index_;
+        index_ = 0;
+
+        Frame frame;
+        for (int32_t i = 0; i < waiting_frame; ++i)
+        {
+            try
+            {
+                frame.read(socket_);
+                uint8_t index = frame.index();
+
+                callbacks_[index].was_run = true;
+                if (not callbacks_[index].process(frame))
+                {
+                    callbacks_[index].error();
+                }
+            }
+            catch(std::exception const& e)
+            {
+                std::cout << e.what() << std::endl;
+            }
+        }
+
+        for (int32_t i = 0; i < waiting_frame; ++i)
+        {
+            if (callbacks_[i].was_run == false)
+            {
+                // frame was lost
+                callbacks_[i].error();
+            }
+        }
+    }
+
+
+    void Link::writeThenRead(Frame& frame)
+    {
+        frame.write(socket_);
+        frame.read(socket_);
+    }
+}

--- a/unit/frame-t.cc
+++ b/unit/frame-t.cc
@@ -67,7 +67,7 @@ TEST(Frame, write_multiples_datagrams)
     .WillOnce(Invoke([&](uint8_t const* frame, int32_t frame_size)
     {
         EXPECT_EQ(EXPECTED_SIZE, frame_size);
-    
+
         {
             EthernetHeader const* header = reinterpret_cast<EthernetHeader const*>(frame);
             EXPECT_EQ(ETH_ETHERCAT_TYPE, header->type);
@@ -85,7 +85,7 @@ TEST(Frame, write_multiples_datagrams)
 
         for (int32_t i = 0; i < 3; ++i)
         {
-            uint8_t const* datagram = reinterpret_cast<uint8_t const*>(frame + sizeof(EthernetHeader) + sizeof(EthercatHeader) 
+            uint8_t const* datagram = reinterpret_cast<uint8_t const*>(frame + sizeof(EthernetHeader) + sizeof(EthercatHeader)
                                                                         + i * (sizeof(DatagramHeader) + PAYLOAD_SIZE + ETHERCAT_WKC_SIZE));
             DatagramHeader const* header = reinterpret_cast<DatagramHeader const*>(datagram);
             uint8_t const* payload = datagram + sizeof(DatagramHeader);
@@ -128,7 +128,7 @@ TEST(Frame, write_multiples_datagrams)
                 }
             }
         }
-        
+
         return EXPECTED_SIZE;
     }));
     frame.write(io);
@@ -271,15 +271,4 @@ TEST(Frame, move_constructor)
 
     Frame frameB = std::move(frameA);
     ASSERT_EQ(2, frameB.datagramCounter());
-}
-
-TEST(Frame, write_then_read_garbage)
-{
-    std::shared_ptr<MockSocket> io = std::make_shared<MockSocket>();
-    Frame frame{PRIMARY_IF_MAC};
-
-    EXPECT_CALL(*io, write(_,ETH_MIN_SIZE)).WillOnce(Return(ETH_MIN_SIZE));
-    EXPECT_CALL(*io, read(_, ETH_MAX_SIZE)).WillOnce(Return(ETH_MIN_SIZE));
-    frame.writeThenRead(io);
-    ASSERT_TRUE(frame.isDatagramAvailable());
 }


### PR DESCRIPTION
The first goal of this work is to enable KickCAT to manage multiples frames inflight to better manage latency.

Add a link layer to refine link access:
- let the users do multiples write in a row
- for future use: it will handle NIC redundancy

Add 'complex' API to let user handle more precisely frames management.
Construct 'basic' API on top of complex one.
Rework error handling when receiving consecutive frames (require to keep the frames inflight coherency)

Note: this is a first step, the ultimate goal is to handle frames at 'link' layer and datagrams at bus layer
