### PR TITLE
Fix: link layer doesn't handle client exception properly.

### DIFF
--- a/example/easycat_example.cc
+++ b/example/easycat_example.cc
@@ -136,7 +136,7 @@ int main(int argc, char* argv[])
         }
         catch (std::exception const& e)
         {
-            int delta = i - last_error;
+            int64_t delta = i - last_error;
             last_error = i;
             std::cerr << e.what() << " at " << i << " delta: " << delta << std::endl;
         }

--- a/include/kickcat/Bus.h
+++ b/include/kickcat/Bus.h
@@ -33,7 +33,7 @@ namespace kickcat
         void requestState(State request);
 
         // Get the state a specific slave
-        State getCurrentState(Slave const& slave);
+        State getCurrentState(Slave& slave);
 
         // wait for all slaves to reached a state
         void waitForState(State request, nanoseconds timeout);
@@ -47,8 +47,9 @@ namespace kickcat
 
         std::vector<Slave>& slaves() { return slaves_; }
 
-        // asynchrone read/write/mailbox methods
+        // asynchrone read/write/mailbox/state methods
         // It enable users to do one or multiple operations in a row, process something, and process all awaiting frames.
+        void sendGetALStatus(Slave& slave, std::function<void()> const& error);
 
         void sendLogicalRead(std::function<void()> const& error);
         void sendLogicalWrite(std::function<void()> const& error);

--- a/include/kickcat/LinuxSocket.h
+++ b/include/kickcat/LinuxSocket.h
@@ -8,7 +8,7 @@ namespace kickcat
     class LinuxSocket : public AbstractSocket
     {
     public:
-        LinuxSocket() = default;
+        LinuxSocket(microseconds rx_coalescing = -1us);
         virtual ~LinuxSocket()
         {
             close();
@@ -21,6 +21,7 @@ namespace kickcat
 
     private:
         int fd_{-1};
+        microseconds rx_coalescing_;
     };
 }
 

--- a/include/kickcat/Slave.h
+++ b/include/kickcat/Slave.h
@@ -18,6 +18,8 @@ namespace kickcat
         void printErrorCounters() const;
 
         uint16_t address;
+        uint8_t al_status{State::INVALID};
+        uint16_t al_status_code;
 
         uint32_t vendor_id;
         uint32_t product_code;

--- a/include/kickcat/protocol.h
+++ b/include/kickcat/protocol.h
@@ -424,20 +424,10 @@ namespace kickcat
     constexpr uint8_t SECONDARY_IF_MAC[6] = { 0x02, 0x00, 0xCA, 0xFF, 0xEE, 0xFF };
 
     // helpers
-
     constexpr uint16_t datagram_size(uint16_t data_size)
     {
         return sizeof(DatagramHeader) + data_size + sizeof(uint16_t);
     }
-
-    /// extract the n-ieme byte of a contiguous data T
-    template<typename T>
-    constexpr uint8_t extractByte(int32_t n, T const& data)
-    {
-        int32_t bit_pos = (n - 1) * 8;
-        return static_cast<uint8_t>((data >> bit_pos) & 0xFF);
-    }
-
 
     /// create a position or node address
     constexpr uint32_t createAddress(uint16_t position, uint16_t offset)

--- a/src/CoE.cc
+++ b/src/CoE.cc
@@ -1,5 +1,4 @@
 #include <cstring>
-//#include <algorithm>
 
 #include "Bus.h"
 


### PR DESCRIPTION
Add: async call (inflight datagram) to retrieve AL status code and AL error code
Improve: retrieve whole AL status (code + error) in one access instead of two access.
