### PR TITLE
Various improvements following industrial usage

### DIFF
--- a/include/kickcat/AbstractSocket.h
+++ b/include/kickcat/AbstractSocket.h
@@ -17,6 +17,7 @@ namespace kickcat
         virtual ~AbstractSocket() = default;
 
         virtual void open(std::string const& interface, microseconds timeout) = 0;
+        virtual void setTimeout(microseconds timeout) = 0;
         virtual void close() noexcept = 0;
         virtual int32_t read(uint8_t* frame, int32_t frame_size) = 0;
         virtual int32_t write(uint8_t const* frame, int32_t frame_size) = 0;

--- a/include/kickcat/Bus.h
+++ b/include/kickcat/Bus.h
@@ -50,27 +50,29 @@ namespace kickcat
 
         // asynchrone read/write/mailbox/state methods
         // It enable users to do one or multiple operations in a row, process something, and process all awaiting frames.
-        void sendGetALStatus(Slave& slave, std::function<void()> const& error);
+        void sendGetALStatus(Slave& slave, std::function<void(DatagramState const&)> const& error);
 
-        void sendLogicalRead(std::function<void()> const& error);
-        void sendLogicalWrite(std::function<void()> const& error);
-        void sendLogicalReadWrite(std::function<void()> const& error);
-        void sendMailboxesChecks(std::function<void()> const& error);   // Fetch in/out mailboxes states (full/empty) of compatible slaves
-        void sendNop(std::function<void()> const& error);               // Send a NOP datagram
+        void sendLogicalRead(std::function<void(DatagramState const&)> const& error);
+        void sendLogicalWrite(std::function<void(DatagramState const&)> const& error);
+        void sendLogicalReadWrite(std::function<void(DatagramState const&)> const& error);
+        void sendMailboxesReadChecks (std::function<void(DatagramState const&)> const& error);  // Fetch in  mailboxes states (full/empty) of compatible slaves
+        void sendMailboxesWriteChecks(std::function<void(DatagramState const&)> const& error);  // Fetch out mailboxes states (full/empty) of compatible slaves
+        void sendNop(std::function<void(DatagramState const&)> const& error);                   // Send a NOP datagram
         void processAwaitingFrames();
 
         // Process messages (read or write slave mailbox) - one at once per slave.
-        void sendReadMessages(std::function<void()> const& error);
-        void sendWriteMessages(std::function<void()> const& error);
-        void sendrefreshErrorCounters(std::function<void()> const& error);
+        void sendReadMessages(std::function<void(DatagramState const&)> const& error);
+        void sendWriteMessages(std::function<void(DatagramState const&)> const& error);
+        void sendRefreshErrorCounters(std::function<void(DatagramState const&)> const& error);
 
-        // helpers around start/finalize oeprations
-        void processDataRead(std::function<void()> const& error);
-        void processDataWrite(std::function<void()> const& error);
-        void processDataReadWrite(std::function<void()> const& error);
+        // helpers around start/finalize operations
+        void finalizeDatagrams(); // send a frame if there is awaiting datagram inside
+        void processDataRead(std::function<void(DatagramState const&)> const& error);
+        void processDataWrite(std::function<void(DatagramState const&)> const& error);
+        void processDataReadWrite(std::function<void(DatagramState const&)> const& error);
 
-        void checkMailboxes( std::function<void()> const& error);
-        void processMessages(std::function<void()> const& error);
+        void checkMailboxes( std::function<void(DatagramState const&)> const& error);
+        void processMessages(std::function<void(DatagramState const&)> const& error);
 
         enum Access
         {

--- a/include/kickcat/LinuxSocket.h
+++ b/include/kickcat/LinuxSocket.h
@@ -8,13 +8,14 @@ namespace kickcat
     class LinuxSocket : public AbstractSocket
     {
     public:
-        LinuxSocket(microseconds rx_coalescing = -1us);
+        LinuxSocket(microseconds rx_coalescing = -1us, microseconds polling_period = 20us);
         virtual ~LinuxSocket()
         {
             close();
         }
 
         void open(std::string const& interface, microseconds timeout) override;
+        void setTimeout(microseconds timeout) override;
         void close() noexcept override;
         int32_t read(uint8_t* frame, int32_t frame_size) override;
         int32_t write(uint8_t const* frame, int32_t frame_size) override;
@@ -22,6 +23,8 @@ namespace kickcat
     private:
         int fd_{-1};
         microseconds rx_coalescing_;
+        microseconds timeout_;
+        microseconds polling_period_;
     };
 }
 

--- a/include/kickcat/Slave.h
+++ b/include/kickcat/Slave.h
@@ -3,6 +3,7 @@
 
 #include <vector>
 #include <string_view>
+#include <sstream>
 
 #include "protocol.h"
 #include "Mailbox.h"
@@ -14,8 +15,21 @@ namespace kickcat
         void parseSII();
 
         void printInfo() const;
+        std::string getInfo() const;
+
         void printPDOs() const;
+        std::string getPDOs() const;
+
         void printErrorCounters() const;
+        std::string getErrorCounters() const;
+        int computeErrorCounters() const;
+
+        /// \return the number of new errors since last call.
+        int computeRelativeErrorCounters();
+
+        /// \brief  Check the total number of errors since start of the slave
+        /// \return True if too many errors detected since start of the slave. Return false otherwise.
+        bool checkAbsoluteErrorCounters(int max_absolute_errors);
 
         uint16_t address;
         uint8_t al_status{State::INVALID};
@@ -62,6 +76,7 @@ namespace kickcat
         PIMapping output;
 
         ErrorCounters error_counters;
+        int previous_errors_sum{0};
 
     private:
         void parseStrings(uint8_t const* section_start);

--- a/src/CoE.cc
+++ b/src/CoE.cc
@@ -6,7 +6,7 @@ namespace kickcat
 {
     void Bus::waitForMessage(std::shared_ptr<AbstractMessage> message, nanoseconds timeout)
     {
-        auto error_callback = [](){ THROW_ERROR("error while checking mailboxes"); };
+        auto error_callback = [](DatagramState const&){ THROW_ERROR("error while checking mailboxes"); };
         nanoseconds now = since_epoch();
 
         while (message->status() == MessageStatus::RUNNING)

--- a/src/Mailbox.cc
+++ b/src/Mailbox.cc
@@ -146,7 +146,7 @@ namespace kickcat
             }
             else
             {
-                header_->len += size;
+                header_->len += static_cast<uint16_t>(size);
                 std::memcpy(payload_, &size, sizeof(uint32_t));
                 std::memcpy(payload_ + sizeof(uint32_t), data, size);
             }

--- a/unit/Mocks.h
+++ b/unit/Mocks.h
@@ -8,6 +8,7 @@ namespace kickcat
     {
     public:
         MOCK_METHOD(void,    open,  (std::string const& interface, microseconds timeout), (override));
+        MOCK_METHOD(void,    setTimeout,  (microseconds timeout), (override));
         MOCK_METHOD(void,    close, (), (noexcept override));
         MOCK_METHOD(int32_t, read,  (uint8_t* frame, int32_t frame_size), (override));
         MOCK_METHOD(int32_t, write, (uint8_t const* frame, int32_t frame_size), (override));

--- a/unit/frame-t.cc
+++ b/unit/frame-t.cc
@@ -55,7 +55,7 @@ TEST(Frame, write_multiples_datagrams)
     uint8_t buffer[PAYLOAD_SIZE];
     for (int32_t i = 0; i < PAYLOAD_SIZE; ++i)
     {
-        buffer[i] = i*i;
+        buffer[i] = static_cast<uint8_t>(i * i);
     }
 
     frame.addDatagram(17, Command::FPRD, 20, nullptr, PAYLOAD_SIZE);
@@ -126,6 +126,7 @@ TEST(Frame, write_multiples_datagrams)
                     }
                     break;
                 }
+                default: {}
             }
         }
 
@@ -142,7 +143,7 @@ TEST(Frame, nextDatagram)
     uint8_t buffer[PAYLOAD_SIZE];
     for (int32_t i = 0; i < PAYLOAD_SIZE; ++i)
     {
-        buffer[i] = i*i;
+        buffer[i] = static_cast<uint8_t>(i * i);
     }
 
     frame.addDatagram(17, Command::FPRD, 20, nullptr, PAYLOAD_SIZE);
@@ -188,6 +189,10 @@ TEST(Frame, nextDatagram)
                 {
                     ASSERT_EQ(static_cast<uint8_t>(j*j), payload[j]);
                 }
+                break;
+            }
+            default:
+            {
                 break;
             }
         }


### PR DESCRIPTION
Fix: handle timeout by polling socket instead of delegating to Linux … kernel (kernel precision is too low for a realtime behavior @ 1 kHz)

Update: error handler now takes the error reason in argument to let the user takes the right decision (a lost datagram is different from a non responsive slave)
Various cleanup and fixes (gcc warnings, ASAN and UBSAN feedback).