### PR TITLE
Allow to repeat slave detection step in case a slave is not ready.

### DIFF
--- a/include/kickcat/Bus.h
+++ b/include/kickcat/Bus.h
@@ -33,6 +33,9 @@ namespace kickcat
         /// \return the number of slaves detected on the bus
         int32_t detectedSlaves() const;
 
+        /// \return the number of slaves detected on the bus
+        int32_t detectSlaves();
+
         // request a state for all slaves
         void requestState(State request);
 
@@ -104,7 +107,6 @@ namespace kickcat
         std::tuple<DatagramHeader const*, T const*, uint16_t> nextDatagram();
 
         // INIT state methods
-        void detectSlaves();
         void resetSlaves(nanoseconds watchdog);
         void setAddresses();
         void configureMailboxes();

--- a/include/kickcat/Error.h
+++ b/include/kickcat/Error.h
@@ -4,14 +4,17 @@
 #include <exception>
 #include <system_error>
 
+#include "KickCAT.h"
+
 namespace kickcat
 {
     #define STR1(x) #x
     #define STR2(x) STR1(x)
     #define LOCATION __FILE__ ":" STR2(__LINE__)
-    #define THROW_ERROR(msg)            (throw Error{LOCATION ": " msg})
-    #define THROW_ERROR_CODE(msg, code) (throw ErrorCode{LOCATION ": " msg, static_cast<int32_t>(code)})
-    #define THROW_SYSTEM_ERROR(msg)     (throw std::system_error(errno, std::generic_category(), LOCATION ": " msg))
+    #define THROW_ERROR(msg)                 (throw Error{LOCATION ": " msg})
+    #define THROW_ERROR_CODE(msg, code)      (throw ErrorCode{LOCATION ": " msg, static_cast<int32_t>(code)})
+    #define THROW_ERROR_DATAGRAM(msg, state) (throw ErrorDatagram{LOCATION ": " msg, state})
+    #define THROW_SYSTEM_ERROR(msg)          (throw std::system_error(errno, std::generic_category(), LOCATION ": " msg))
 
 #define DEBUG 1
 #ifdef DEBUG
@@ -49,6 +52,23 @@ namespace kickcat
 
     private:
         int32_t code_;
+    };
+
+    struct ErrorDatagram : public Error
+    {
+        ErrorDatagram(char const* message, DatagramState state)
+        : Error(message)
+        {
+            state_ = state;
+        }
+
+        DatagramState state() const noexcept
+        {
+            return state_;
+        }
+
+    private:
+        DatagramState state_;
     };
 }
 

--- a/include/kickcat/KickCAT.h
+++ b/include/kickcat/KickCAT.h
@@ -1,0 +1,32 @@
+#ifndef KICKAT_H
+#define KICKAT_H
+
+namespace kickcat
+{
+    enum class DatagramState
+    {
+        LOST,
+        SEND_ERROR,
+        INVALID_WKC,
+        NO_HANDLER,
+        OK
+    };
+
+    constexpr char const* toString(DatagramState src)
+    {
+        switch (src)
+        {
+            case DatagramState::LOST:        { return "LOST";       }
+            case DatagramState::SEND_ERROR:  { return "SEND_ERROR"; }
+            case DatagramState::INVALID_WKC: { return "INVALID_WKC";}
+            case DatagramState::NO_HANDLER:  { return "NO_HANDLER"; }
+            case DatagramState::OK:          { return "OK";         }
+            default:
+            {
+                return "Unknown";
+            }
+        }
+    }
+}
+
+#endif

--- a/include/kickcat/Link.h
+++ b/include/kickcat/Link.h
@@ -5,20 +5,12 @@
 #include <memory>
 #include <functional>
 
+#include "KickCAT.h"
 #include "Frame.h"
 
 namespace kickcat
 {
     class AbstractSocket;
-
-    enum class DatagramState
-    {
-        LOST,
-        SEND_ERROR,
-        INVALID_WKC,
-        NO_HANDLER,
-        OK
-    };
 
     /// \brief Handle link layer
     /// \details This class is responsible to handle frames and datagrams on the link layers:

--- a/src/CoE.cc
+++ b/src/CoE.cc
@@ -6,7 +6,10 @@ namespace kickcat
 {
     void Bus::waitForMessage(std::shared_ptr<AbstractMessage> message, nanoseconds timeout)
     {
-        auto error_callback = [](DatagramState const&){ THROW_ERROR("error while checking mailboxes"); };
+        auto error_callback = [](DatagramState const& state)
+        {
+            THROW_ERROR_DATAGRAM("error while checking mailboxes", state);
+        };
         nanoseconds now = since_epoch();
 
         while (message->status() == MessageStatus::RUNNING)
@@ -17,7 +20,7 @@ namespace kickcat
 
             if (elapsed_time(now) > timeout)
             {
-                THROW_ERROR("Timeout");
+                THROW_ERROR("Error while reading SDO - Timeout");
             }
         }
     }

--- a/unit/bus-t.cc
+++ b/unit/bus-t.cc
@@ -24,7 +24,7 @@ public:
     void SetUp() override
     {
         bus.configureWaitLatency(0ns, 0ns);
-        init_bus();
+        initBus();
     }
 
     template<typename T>
@@ -121,7 +121,7 @@ public:
         }
     }
 
-    void init_bus(milliseconds watchdog = 100ms)
+    void initBus(milliseconds watchdog = 100ms)
     {
         InSequence s;
 
@@ -558,7 +558,6 @@ TEST_F(BusTest, read_SDO_buffer_too_small)
 }
 
 
-
 TEST_F(BusTest, detect_mapping_CoE)
 {
     InSequence s;
@@ -596,13 +595,21 @@ TEST_F(BusTest, pdio_watchdogs)
         slave.sii.RxPDO.clear();
     };
     clearForInit();
-    init_bus(0ms);
+    initBus(0ms);
     clearForInit();
-    init_bus(1234ms);
+    initBus(1234ms);
     clearForInit();
 
     detectAndReset();
     ASSERT_THROW(bus.init(10s), Error);
     detectAndReset();
     ASSERT_THROW(bus.init(-1s), Error);
+}
+
+
+TEST_F(BusTest, init_no_slave_detected)
+{
+    checkSendFrame(Command::BRD);
+    handleReply(0);
+    ASSERT_THROW(bus.init(), Error);
 }


### PR DESCRIPTION
close #23 

Also add a new Exception type to handle Datagram Error and expose the datagram state to the client.