### PR TITLE
Fix conflict with pikeos 5.1 ETH_FCS_SIZE definition

### DIFF
--- a/include/kickcat/protocol.h
+++ b/include/kickcat/protocol.h
@@ -19,7 +19,9 @@ namespace kickcat
     } __attribute__((__packed__));
 
     constexpr int32_t  ETH_MTU_SIZE = 1500;
+#ifndef ETH_FCS_SIZE
     constexpr int32_t  ETH_FCS_SIZE = 4;
+#endif
     constexpr int32_t  ETH_MAX_SIZE = sizeof(EthernetHeader) + ETH_MTU_SIZE + ETH_FCS_SIZE;
     constexpr int32_t  ETH_MIN_SIZE = 60; // Ethernet disallow sending less than 64 bytes (60 + FCS)
 


### PR DESCRIPTION
When building for pikeos I ran into a conflict on the ETH_FCS_SIZE definition. 
It was already defined `pikeos-5.1/target/arm/v8hf/driver/include/net/utils/ethernet.h` and I had a file using both kickcat protocol.h and including this file leading to the conflict.