### PR TITLE
Prints moved to Prints.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ set(LIB_SOURCES
   ${CMAKE_CURRENT_SOURCE_DIR}/src/Frame.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/src/Link.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/src/Mailbox.cc
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/Prints.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/src/protocol.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/src/Slave.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/src/Time.cc
@@ -56,6 +57,7 @@ if (GTest_FOUND)
                               unit/frame-t.cc
                               unit/link-t.cc
                               unit/mailbox-t.cc
+                              unit/prints-t.cc
                               unit/protocol-t.cc
                               unit/slave-t.cc
   )
@@ -78,7 +80,7 @@ if (GTest_FOUND)
     setup_target_for_coverage_gcovr_html(
         NAME coverage
         EXECUTABLE kickcat_unit
-        EXCLUDE "unit/*" ".*gtest.*" "example" ".*gmock.*" ".*LinuxSocket*"
+        EXCLUDE "unit/*" ".*gtest.*" "example" ".*gmock.*" ".*LinuxSocket*" "src/Prints.cc"
         )
   endif()
 endif()

--- a/examples/easycat/easycat_example.cc
+++ b/examples/easycat/easycat_example.cc
@@ -1,4 +1,5 @@
 #include "kickcat/Bus.h"
+#include "kickcat/Prints.h"
 
 #ifdef __linux__
     #include "kickcat/OS/Linux/Socket.h"
@@ -136,7 +137,7 @@ int main(int argc, char* argv[])
 
             if ((i % 1000) == 0)
             {
-                easycat.printErrorCounters();
+                printErrorCounters(easycat);
             }
 
             microseconds sample = duration_cast<microseconds>(t4 - t3 + t2 - t1);

--- a/include/kickcat/Diagnostics.h
+++ b/include/kickcat/Diagnostics.h
@@ -1,6 +1,9 @@
-#include <unordered_map>
+#ifndef KICKCAT_DIAGNOSTICS_H
+#define KICKCAT_DIAGNOSTICS_H
+
 #include "Slave.h"
-#include <cstdint>
+
+#include <unordered_map>
 #include <vector>
 
 namespace kickcat
@@ -8,6 +11,6 @@ namespace kickcat
     /// \brief return the topology of discovered network - To be called after bus.getDLStatus()
     /// \return [key, value] pair : [slave adress, parent address] (the only slave that is its own parent is linked to the master) 
     std::unordered_map<uint16_t, uint16_t> getTopology(std::vector<Slave>& slaves);
-
-    void printTopology(std::unordered_map<uint16_t, uint16_t> map);
 }
+
+#endif

--- a/include/kickcat/Prints.h
+++ b/include/kickcat/Prints.h
@@ -10,14 +10,14 @@
 namespace kickcat
 {
     // Slaves utils
-    void printInfo(Slave slave);
-    void printPDOs(Slave slave);
-    void printErrorCounters(Slave slave);
-    void printDLStatus(Slave slave);
-    void printGeneralEntry(Slave slave);
+    void printInfo(const Slave& slave);
+    void printPDOs(const Slave& slave);
+    void printErrorCounters(const Slave& slave);
+    void printDLStatus(const Slave& slave);
+    void printGeneralEntry(const Slave& slave);
 
     // Topology utils
-    void printTopology(std::unordered_map<uint16_t, uint16_t> map);
+    void printTopology(const std::unordered_map<uint16_t, uint16_t>& topology_mapping);
 }
 
 #endif

--- a/include/kickcat/Prints.h
+++ b/include/kickcat/Prints.h
@@ -1,0 +1,23 @@
+#ifndef KICKCAT_PRINTS_H
+#define KICKCAT_PRINTS_H
+
+#include <unordered_map>
+#include <cstdint>
+
+#include "Slave.h"
+
+
+namespace kickcat
+{
+    // Slaves utils
+    void printInfo(Slave slave);
+    void printPDOs(Slave slave);
+    void printErrorCounters(Slave slave);
+    void printDLStatus(Slave slave);
+    void printGeneralEntry(Slave slave);
+
+    // Topology utils
+    void printTopology(std::unordered_map<uint16_t, uint16_t> map);
+}
+
+#endif

--- a/include/kickcat/Prints.h
+++ b/include/kickcat/Prints.h
@@ -10,14 +10,14 @@
 namespace kickcat
 {
     // Slaves utils
-    void printInfo(const Slave& slave);
-    void printPDOs(const Slave& slave);
-    void printErrorCounters(const Slave& slave);
-    void printDLStatus(const Slave& slave);
-    void printGeneralEntry(const Slave& slave);
+    void printInfo(Slave const& slave);
+    void printPDOs(Slave const& slave);
+    void printErrorCounters(Slave const& slave);
+    void printDLStatus(Slave const& slave);
+    void printGeneralEntry(Slave const& slave);
 
     // Topology utils
-    void printTopology(const std::unordered_map<uint16_t, uint16_t>& topology_mapping);
+    void printTopology(std::unordered_map<uint16_t, uint16_t> const& topology_mapping);
 }
 
 #endif

--- a/include/kickcat/Slave.h
+++ b/include/kickcat/Slave.h
@@ -14,13 +14,10 @@ namespace kickcat
     {
         void parseSII();
 
-        void printInfo() const;
         std::string getInfo() const;
 
-        void printPDOs() const;
         std::string getPDOs() const;
 
-        void printErrorCounters() const;
         ErrorCounters const& errorCounters() const;
         int computeErrorCounters() const;
 
@@ -32,8 +29,6 @@ namespace kickcat
         bool checkAbsoluteErrorCounters(int max_absolute_errors);
         
         int countOpenPorts();
-
-        void printDLStatus();
 
         uint16_t address;
         uint8_t al_status{State::INVALID};

--- a/src/Diagnostics.cc
+++ b/src/Diagnostics.cc
@@ -55,20 +55,4 @@ namespace kickcat
         }
         return topology;
     }
-
-    void printTopology(std::unordered_map<uint16_t, uint16_t> topology)
-    {  
-        printf( "\n -*-*-*-*- Topology -*-*-*-*-\n" );
-        for (auto& it : topology)
-        {
-            if (it.first != it.second)
-            {
-                printf( "Slave %04x parent : slave %04x \n", it.first, it.second);
-            }
-            else
-            {
-                printf( "Slave %04x parent : master \n", it.first);
-            }
-        }
-    }
 }

--- a/src/Prints.cc
+++ b/src/Prints.cc
@@ -41,10 +41,11 @@ namespace kickcat
         printf("  Loop Function :  %d \n", slave.dl_status.LOOP_port3);
     }
 
-    void printGeneralEntry(Slave const& slave) {
+    void printGeneralEntry(Slave const& slave) 
+    {
         eeprom::GeneralEntry const* general_entry = slave.sii.general;
         
-        if (general_entry == NULL)
+        if (general_entry == nullptr)
         {
             printf("Uninitialized SII - Nothing to print");
         }

--- a/src/Prints.cc
+++ b/src/Prints.cc
@@ -2,22 +2,22 @@
 
 namespace kickcat
 {
-    void printInfo(Slave slave)
+    void printInfo(const Slave& slave)
     {
         printf("%s", slave.getInfo().c_str());
     }
 
-    void printPDOs(Slave slave)
+    void printPDOs(const Slave& slave)
     {
         printf("%s", slave.getPDOs().c_str());
     }
 
-    void printErrorCounters(Slave slave)
+    void printErrorCounters(const Slave& slave)
     {
         printf("\n -*-*-*-*- slave %u -*-*-*-*-\n %s", slave.address, toString(slave.error_counters).c_str());
     }
 
-    void printDLStatus(Slave slave)
+    void printDLStatus(const Slave& slave)
     {
         printf("\n -*-*-*-*- slave %u -*-*-*-*-\n", slave.address);
         printf("Port 0: \n");
@@ -41,7 +41,7 @@ namespace kickcat
         printf("  Loop Function :  %d \n", slave.dl_status.LOOP_port3);
     }
 
-    void printGeneralEntry(Slave slave) {
+    void printGeneralEntry(const Slave& slave) {
         eeprom::GeneralEntry const* general_entry = slave.sii.general;
         
         if (general_entry == NULL)
@@ -74,10 +74,10 @@ namespace kickcat
     }
 
 
-    void printTopology(std::unordered_map<uint16_t, uint16_t> topology)
+    void printTopology(const std::unordered_map<uint16_t, uint16_t>& topology_mapping)
     {  
         printf( "\n -*-*-*-*- Topology -*-*-*-*-\n" );
-        for (auto& it : topology)
+        for (auto& it : topology_mapping)
         {
             if (it.first != it.second)
             {

--- a/src/Prints.cc
+++ b/src/Prints.cc
@@ -1,0 +1,92 @@
+#include "Prints.h"
+
+namespace kickcat
+{
+    void printInfo(Slave slave)
+    {
+        printf("%s", slave.getInfo().c_str());
+    }
+
+    void printPDOs(Slave slave)
+    {
+        printf("%s", slave.getPDOs().c_str());
+    }
+
+    void printErrorCounters(Slave slave)
+    {
+        printf("\n -*-*-*-*- slave %u -*-*-*-*-\n %s", slave.address, toString(slave.error_counters).c_str());
+    }
+
+    void printDLStatus(Slave slave)
+    {
+        printf("\n -*-*-*-*- slave %u -*-*-*-*-\n", slave.address);
+        printf("Port 0: \n");
+        printf("  Physical Link :  %d \n", slave.dl_status.PL_port0);
+        printf("  Communications : %d \n", slave.dl_status.COM_port0);
+        printf("  Loop Function :  %d \n", slave.dl_status.LOOP_port0);
+
+        printf("Port 1: \n");
+        printf("  Physical Link :  %d \n", slave.dl_status.PL_port1);
+        printf("  Communications : %d \n", slave.dl_status.COM_port1);
+        printf("  Loop Function :  %d \n", slave.dl_status.LOOP_port1);
+
+        printf("Port 2: \n");
+        printf("  Physical Link :  %d \n", slave.dl_status.PL_port2);
+        printf("  Communications : %d \n", slave.dl_status.COM_port2);
+        printf("  Loop Function :  %d \n", slave.dl_status.LOOP_port2);
+
+        printf("Port 3: \n");
+        printf("  Physical Link :  %d \n", slave.dl_status.PL_port3);
+        printf("  Communications : %d \n", slave.dl_status.COM_port3);
+        printf("  Loop Function :  %d \n", slave.dl_status.LOOP_port3);
+    }
+
+    void printGeneralEntry(Slave slave) {
+        eeprom::GeneralEntry const* general_entry = slave.sii.general;
+        
+        if (general_entry == NULL)
+        {
+            printf("Uninitialized SII - Nothing to print");
+        }
+        else
+        {
+            printf( "group_info_id: %i \n",             general_entry->group_info_id);
+            printf( "image_name_id: %i \n",             general_entry->image_name_id);
+            printf( "device_order_id: %i \n",           general_entry->device_order_id);
+            printf( "device_name_id: %i \n",            general_entry->device_name_id);
+            printf( "reserved_A: %i \n",                general_entry->reserved_A);
+            printf( "FoE_details: %i \n",               general_entry->FoE_details);
+            printf( "EoE_details: %i \n",               general_entry->EoE_details);
+            printf( "SoE_channels: %i \n",              general_entry->SoE_channels);
+            printf( "DS402_channels: %i \n",            general_entry->DS402_channels);
+            printf( "SysmanClass: %i \n",               general_entry->SysmanClass);
+            printf( "flags: %i \n",                     general_entry->flags);
+            printf( "current_on_ebus: %i \n",           general_entry->current_on_ebus); // mA, negative means feeding current
+            printf( "group_info_id_dup: %i \n",         general_entry->group_info_id_dup);
+            printf( "reserved_B: %i \n",                general_entry->reserved_B);
+            printf( "physical_memory_address: %i \n",   general_entry->physical_memory_address);
+            printf( "reserved_C[12]: %i \n",            general_entry->reserved_C[12]);
+            printf( "port_0: %04x \n",                  general_entry->port_0);
+            printf( "port_1: %04x \n",                  general_entry->port_1);
+            printf( "port_2: %04x \n",                  general_entry->port_2);
+            printf( "port_3: %04x \n",                  general_entry->port_3);
+        }
+    }
+
+
+    void printTopology(std::unordered_map<uint16_t, uint16_t> topology)
+    {  
+        printf( "\n -*-*-*-*- Topology -*-*-*-*-\n" );
+        for (auto& it : topology)
+        {
+            if (it.first != it.second)
+            {
+                printf( "Slave %04x parent : slave %04x \n", it.first, it.second);
+            }
+            else
+            {
+                printf( "Slave %04x parent : master \n", it.first);
+            }
+        }
+    }
+}

--- a/src/Prints.cc
+++ b/src/Prints.cc
@@ -77,7 +77,7 @@ namespace kickcat
     void printTopology(std::unordered_map<uint16_t, uint16_t> const& topology_mapping)
     {  
         printf( "\n -*-*-*-*- Topology -*-*-*-*-\n" );
-        for (auto& it : topology_mapping)
+        for (auto const& it : topology_mapping)
         {
             if (it.first != it.second)
             {

--- a/src/Prints.cc
+++ b/src/Prints.cc
@@ -2,22 +2,22 @@
 
 namespace kickcat
 {
-    void printInfo(const Slave& slave)
+    void printInfo(Slave const& slave)
     {
         printf("%s", slave.getInfo().c_str());
     }
 
-    void printPDOs(const Slave& slave)
+    void printPDOs(Slave const& slave)
     {
         printf("%s", slave.getPDOs().c_str());
     }
 
-    void printErrorCounters(const Slave& slave)
+    void printErrorCounters(Slave const& slave)
     {
         printf("\n -*-*-*-*- slave %u -*-*-*-*-\n %s", slave.address, toString(slave.error_counters).c_str());
     }
 
-    void printDLStatus(const Slave& slave)
+    void printDLStatus(Slave const& slave)
     {
         printf("\n -*-*-*-*- slave %u -*-*-*-*-\n", slave.address);
         printf("Port 0: \n");
@@ -41,7 +41,7 @@ namespace kickcat
         printf("  Loop Function :  %d \n", slave.dl_status.LOOP_port3);
     }
 
-    void printGeneralEntry(const Slave& slave) {
+    void printGeneralEntry(Slave const& slave) {
         eeprom::GeneralEntry const* general_entry = slave.sii.general;
         
         if (general_entry == NULL)
@@ -74,7 +74,7 @@ namespace kickcat
     }
 
 
-    void printTopology(const std::unordered_map<uint16_t, uint16_t>& topology_mapping)
+    void printTopology(std::unordered_map<uint16_t, uint16_t> const& topology_mapping)
     {  
         printf( "\n -*-*-*-*- Topology -*-*-*-*-\n" );
         for (auto& it : topology_mapping)

--- a/src/Slave.cc
+++ b/src/Slave.cc
@@ -5,31 +5,6 @@
 
 namespace kickcat
 {
-
-    void printGeneralEntry(eeprom::GeneralEntry const* general_entry)
-    {
-        printf( "group_info_id: %i \n",             general_entry->group_info_id);
-        printf( "image_name_id: %i \n",             general_entry->image_name_id);
-        printf( "device_order_id: %i \n",           general_entry->device_order_id);
-        printf( "device_name_id: %i \n",            general_entry->device_name_id);
-        printf( "reserved_A: %i \n",                general_entry->reserved_A);
-        printf( "FoE_details: %i \n",               general_entry->FoE_details);
-        printf( "EoE_details: %i \n",               general_entry->EoE_details);
-        printf( "SoE_channels: %i \n",              general_entry->SoE_channels);
-        printf( "DS402_channels: %i \n",            general_entry->DS402_channels);
-        printf( "SysmanClass: %i \n",               general_entry->SysmanClass);
-        printf( "flags: %i \n",                     general_entry->flags);
-        printf( "current_on_ebus: %i \n",           general_entry->current_on_ebus); // mA, negative means feeding current
-        printf( "group_info_id_dup: %i \n",         general_entry->group_info_id_dup);
-        printf( "reserved_B: %i \n",                general_entry->reserved_B);
-        printf( "physical_memory_address: %i \n",   general_entry->physical_memory_address);
-        printf( "reserved_C[12]: %i \n",            general_entry->reserved_C[12]);
-        printf( "port_0: %04x \n",                  general_entry->port_0);
-        printf( "port_1: %04x \n",                  general_entry->port_1);
-        printf( "port_2: %04x \n",                  general_entry->port_2);
-        printf( "port_3: %04x \n",                  general_entry->port_3);
-    }
-
     void Slave::parseStrings(uint8_t const* section_start)
     {
         sii.strings.push_back(std::string_view()); // index 0 is an empty string
@@ -163,13 +138,6 @@ namespace kickcat
         };
     }
 
-
-    void Slave::printInfo() const
-    {
-        printf("%s", getInfo().c_str());
-    }
-
-
     std::string Slave::getInfo() const
     {
         std::stringstream os;
@@ -209,13 +177,6 @@ namespace kickcat
         return os.str();
     }
 
-
-    void Slave::printPDOs() const
-    {
-        printf("%s", getPDOs().c_str());
-    }
-
-
     std::string Slave::getPDOs() const
     {
         std::stringstream os;
@@ -248,11 +209,6 @@ namespace kickcat
         return os.str();
     }
 
-
-    void Slave::printErrorCounters() const
-    {
-        printf("\n -*-*-*-*- slave %u -*-*-*-*-\n %s", address, toString(error_counters).c_str());
-    }
 
     ErrorCounters const& Slave::errorCounters() const
     {
@@ -296,30 +252,4 @@ namespace kickcat
                 dl_status.PL_port2 +
                 dl_status.PL_port3;
     }
-
-    void Slave::printDLStatus()
-    {
-        printf("\n -*-*-*-*- slave %u -*-*-*-*-\n", address);
-        printf("Port 0: \n");
-        printf("  Physical Link :  %d \n", dl_status.PL_port0);
-        printf("  Communications : %d \n", dl_status.COM_port0);
-        printf("  Loop Function :  %d \n", dl_status.LOOP_port0);
-
-        printf("Port 1: \n");
-        printf("  Physical Link :  %d \n", dl_status.PL_port1);
-        printf("  Communications : %d \n", dl_status.COM_port1);
-        printf("  Loop Function :  %d \n", dl_status.LOOP_port1);
-
-        printf("Port 2: \n");
-        printf("  Physical Link :  %d \n", dl_status.PL_port2);
-        printf("  Communications : %d \n", dl_status.COM_port2);
-        printf("  Loop Function :  %d \n", dl_status.LOOP_port2);
-
-        printf("Port 3: \n");
-        printf("  Physical Link :  %d \n", dl_status.PL_port3);
-        printf("  Communications : %d \n", dl_status.COM_port3);
-        printf("  Loop Function :  %d \n", dl_status.LOOP_port3);
-    }
-
-
 }

--- a/tools/scanTopology.cc
+++ b/tools/scanTopology.cc
@@ -1,5 +1,6 @@
 #include "kickcat/Bus.h"
 #include "kickcat/Diagnostics.h"
+#include "kickcat/Prints.h"
 
 #ifdef __linux__
     #include "kickcat/OS/Linux/Socket.h"
@@ -61,7 +62,7 @@ int main(int argc, char* argv[])
         bus.sendGetDLStatus(slave);
         bus.finalizeDatagrams();
 
-        slave.printDLStatus();
+        printDLStatus(slave);
     }
 
     std::unordered_map<uint16_t, uint16_t> topology = getTopology(bus.slaves());

--- a/unit/prints-t.cc
+++ b/unit/prints-t.cc
@@ -1,0 +1,142 @@
+#include <gtest/gtest.h>
+#include <unordered_map>
+
+#include "kickcat/Slave.h"
+#include "kickcat/Prints.h"
+
+using namespace kickcat;
+
+TEST(Prints, slave_uninitialized_prints)
+{
+    // Test to ensure that nothing explode when using printing helpers (especially when the slave is not initialized)
+    // No check about the content (time consumming and unmaintainable).
+
+    Slave slave;
+    std::unordered_map<uint16_t, uint16_t> topology({{0, 0}, {1, 0}, {2, 1}});
+
+    testing::internal::CaptureStdout();
+    printInfo(slave);
+    std::string output = testing::internal::GetCapturedStdout();
+    ASSERT_LT(300, output.size());
+
+    testing::internal::CaptureStdout();
+    printPDOs(slave);
+    output = testing::internal::GetCapturedStdout();
+    ASSERT_EQ(0, output.size()); // No PDO to print
+
+    testing::internal::CaptureStdout();
+    printErrorCounters(slave);
+    output = testing::internal::GetCapturedStdout();
+    ASSERT_LT(200, output.size());
+
+    testing::internal::CaptureStdout();
+    printDLStatus(slave);
+    output = testing::internal::GetCapturedStdout();
+    ASSERT_LT(200, output.size());
+
+    testing::internal::CaptureStdout();
+    printGeneralEntry(slave);
+    output = testing::internal::GetCapturedStdout();
+    ASSERT_LT(30, output.size());
+
+    testing::internal::CaptureStdout();
+    printTopology(topology);
+    output = testing::internal::GetCapturedStdout();
+    ASSERT_LT(30, output.size());
+
+}
+
+TEST(Prints, slave_initialized_prints)
+{
+    Slave slave;
+    slave.sii.buffer =
+    {
+        // -- Strings
+        0x0014000A,     // Section Strings, 40 bytes
+        0x6f4c1f01,     // one string of 31 bytes
+        0x206d6572,
+        0x75737069,
+        0x6f64206d,
+        0x20726f6c,
+        0x20746973,
+        0x74656d61,
+        0x6f63202c,
+        0x0000006e,
+
+        // -- DataTypes
+        0x00000014,     // Section DataTypes, 0 bytes
+
+        // -- General
+        0x0010001E,     // Section General, 32 bytes
+        0xA5A5A5A5,
+        0xA5A5A5A5,
+        0xA5A5A5A5,
+        0xA5A5A5A5,
+        0xA5A5A5A5,
+        0xA5A5A5A5,
+        0xA5A5A5A5,
+        0xA5A5A5A5,
+
+        // -- FMMU
+        0x00020028,
+        0xFFEEDDCC,
+
+        // -- SyncManagers
+        0x00040029,     // 8 bytes
+        0x00112233,
+        0x44556677,
+
+        // -- TxPDO
+        0x00080032,     // section TxPDO, 16 bytes
+        0x00010000,     // one entry
+        0x00000000,     // 'padding'
+        0x00000000,
+        0x0000FF00,     // 255 bits
+
+        // -- RxPDO
+        0x000C0033,     // section RxPDO, 24 bytes
+        0x00020000,     // two entries
+        0x00000000,     // 'padding'
+        0x00000000,
+        0x0000FF00,     // 255 bits
+        0x00000000,
+        0x00008000,     // 128 bits
+
+        // -- DC
+        0x0000003C,
+
+        // -- NOOP
+        0x00000000,
+        0x00000000,
+
+        // -- End
+        0xFFFFFFFF
+    };
+
+    slave.parseSII();
+    // ensure that print infos displays more stuff when SII is loaded
+    testing::internal::CaptureStdout();
+    printInfo(slave);
+    std::string output = testing::internal::GetCapturedStdout();
+    ASSERT_LT(430, output.size());
+
+    testing::internal::CaptureStdout();
+    printPDOs(slave);
+    output = testing::internal::GetCapturedStdout();
+    ASSERT_LT(100, output.size()); // No PDO to print
+
+    testing::internal::CaptureStdout();
+    printErrorCounters(slave);
+    output = testing::internal::GetCapturedStdout();
+    ASSERT_LT(200, output.size());
+
+    testing::internal::CaptureStdout();
+    printDLStatus(slave);
+    output = testing::internal::GetCapturedStdout();
+    ASSERT_LT(200, output.size());
+
+    testing::internal::CaptureStdout();
+    printGeneralEntry(slave);
+    output = testing::internal::GetCapturedStdout();
+    ASSERT_LT(200, output.size());
+}

--- a/unit/slave-t.cc
+++ b/unit/slave-t.cc
@@ -3,29 +3,6 @@
 
 using namespace kickcat;
 
-TEST(Slave, prints)
-{
-    // Test to ensure that nothing explode when using printing helpers (especially when the slave is not initialized)
-    // No check about the content (time consumming and unmaintainable).
-
-    Slave slave;
-
-    testing::internal::CaptureStdout();
-    slave.printInfo();
-    std::string output = testing::internal::GetCapturedStdout();
-    ASSERT_LT(300, output.size());
-
-    testing::internal::CaptureStdout();
-    slave.printPDOs();
-    output = testing::internal::GetCapturedStdout();
-    ASSERT_EQ(0, output.size()); // No PDO to print
-
-    testing::internal::CaptureStdout();
-    slave.printErrorCounters();
-    output = testing::internal::GetCapturedStdout();
-    ASSERT_LT(200, output.size());
-}
-
 
 TEST(Slave, parse_SII)
 {
@@ -98,17 +75,6 @@ TEST(Slave, parse_SII)
     ASSERT_EQ(2, slave.sii.strings.size()); // 2 strings since 0 is unused
     ASSERT_EQ(4, slave.sii.fmmus_.size());
     ASSERT_EQ(1, slave.sii.syncManagers_.size());
-
-    // ensure that print infos displays more stuff when SII is loaded
-    testing::internal::CaptureStdout();
-    slave.printInfo();
-    std::string output = testing::internal::GetCapturedStdout();
-    ASSERT_LT(430, output.size());
-
-    testing::internal::CaptureStdout();
-    slave.printPDOs();
-    output = testing::internal::GetCapturedStdout();
-    ASSERT_LT(100, output.size()); // No PDO to print
 }
 
 TEST(Slave, countOpenPorts)


### PR DESCRIPTION
This MR tidies things up a bit.
Printing methods are moved to Prints.h, and removed from code coverage reports.