### PR TITLE
Fix circulating bit bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ Note: you can easily provide GTest via conan package manager:
 https://infosys.beckhoff.com/english.php?content=../content/1033/tc3_io_intro/1257993099.html&id=3196541253205318339
 https://www.ethercat.org/download/documents/EtherCAT_Device_Protocol_Poster.pdf
 
+protocol:
+https://download.beckhoff.com/download/document/io/ethercat-development-products/ethercat_esc_datasheet_sec1_technology_2i2.pdf
+
 registers:
 https://download.beckhoff.com/download/Document/io/ethercat-development-products/ethercat_esc_datasheet_sec2_registers_3i0.pdf
 

--- a/src/Frame.cc
+++ b/src/Frame.cc
@@ -90,6 +90,7 @@ namespace kickcat
         header->command = command;
         header->address = address;
         header->len = data_size;
+        header->circulating = 0;
         header->multiple = 1;   // by default, consider that more datagrams will follow
         header->IRQ = 0;        //TODO what's that ?
 


### PR DESCRIPTION
In the datagram header in Frame.cc the field `circulating` was never reset.

The circulating field is set to 1 to indicate that the given frame has already been processed by a slave with the port0 closed. If a slave with a port0 closed try to set set it to 1 and it's already 1, the slave destroy the frame to prevent a frame to circulate indefinitely in a cut network (preventing the slaves to trigger their watchdog when communication with the master is lost).

The problem with kickcat not resetting this field to 0 was that it is not possible to communicate to a slave on its port out, leading to not being able to implement the redundancy handling.


More information about the circulating bit can be found in https://download.beckhoff.com/download/document/io/ethercat-development-products/ethercat_esc_datasheet_sec1_technology_2i2.pdf chapter 3.5, schematics explain the problem in details.