### PR TITLE
Moved DLStatus from reg

### DIFF
--- a/include/kickcat/Bus.h
+++ b/include/kickcat/Bus.h
@@ -54,7 +54,7 @@ namespace kickcat
         // asynchrone read/write/mailbox/state methods
         // It enable users to do one or multiple operations in a row, process something, and process all awaiting frames.
         void sendGetALStatus(Slave& slave, std::function<void(DatagramState const&)> const& error);
-        void sendGetDLStatus(Slave& slave);
+        void sendGetDLStatus(Slave& slave, std::function<void(DatagramState const&)> const& error);
 
         void sendLogicalRead(std::function<void(DatagramState const&)> const& error);
         void sendLogicalWrite(std::function<void(DatagramState const&)> const& error);

--- a/include/kickcat/Slave.h
+++ b/include/kickcat/Slave.h
@@ -47,7 +47,7 @@ namespace kickcat
         uint32_t eeprom_size; // in bytes
         uint16_t eeprom_version;
 
-        reg::DLStatus dl_status;
+        DLStatus dl_status;
 
         struct SII
         {

--- a/include/kickcat/protocol.h
+++ b/include/kickcat/protocol.h
@@ -149,25 +149,24 @@ namespace kickcat
         constexpr uint16_t DC_TIME_FILTER     = 0x934;
         constexpr uint16_t DC_CYCLIC_CONTROL  = 0x980;
         constexpr uint16_t DC_SYNC_ACTIVATION = 0x981;
-
-
-        struct DLStatus
-        {
-            uint16_t unknown : 4,
-                PL_port0 : 1,
-                PL_port1 : 1,
-                PL_port2 : 1,
-                PL_port3 : 1,
-                LOOP_port0 : 1,
-                COM_port0 : 1,
-                LOOP_port1 : 1,
-                COM_port1 : 1,
-                LOOP_port2 : 1,
-                COM_port2 : 1,
-                LOOP_port3 : 1,
-                COM_port3 : 1;
-        }__attribute__((__packed__));
     }
+
+    struct DLStatus
+    {
+        uint16_t unknown : 4,
+            PL_port0 : 1,
+            PL_port1 : 1,
+            PL_port2 : 1,
+            PL_port3 : 1,
+            LOOP_port0 : 1,
+            COM_port0 : 1,
+            LOOP_port1 : 1,
+            COM_port1 : 1,
+            LOOP_port2 : 1,
+            COM_port2 : 1,
+            LOOP_port3 : 1,
+            COM_port3 : 1;
+    }__attribute__((__packed__));
 
     struct ErrorCounters
     {

--- a/src/Bus.cc
+++ b/src/Bus.cc
@@ -934,7 +934,7 @@ namespace kickcat
         }
     }
 
-    void Bus::sendGetDLStatus(Slave& slave)
+    void Bus::sendGetDLStatus(Slave& slave, std::function<void(DatagramState const&)> const& error)
     {
         auto process = [&slave](DatagramHeader const*, uint8_t const* data, uint16_t wkc)
         {
@@ -945,11 +945,6 @@ namespace kickcat
 
             slave.dl_status= *reinterpret_cast<DLStatus const*>(data);
             return DatagramState::OK;
-        };
-
-        auto error = [](DatagramState const&)
-        {
-            THROW_ERROR("Error while trying to get DL Status.");
         };
 
         link_.addDatagram(Command::FPRD, createAddress(slave.address, reg::ESC_DL_STATUS), nullptr, 2, process, error);

--- a/src/Bus.cc
+++ b/src/Bus.cc
@@ -943,7 +943,7 @@ namespace kickcat
                 return DatagramState::INVALID_WKC;
             }
 
-            slave.dl_status= *reinterpret_cast<reg::DLStatus const*>(data);
+            slave.dl_status= *reinterpret_cast<DLStatus const*>(data);
             return DatagramState::OK;
         };
 

--- a/tools/scanTopology.cc
+++ b/tools/scanTopology.cc
@@ -59,7 +59,7 @@ int main(int argc, char* argv[])
 
     for (auto& slave : bus.slaves())
     {
-        bus.sendGetDLStatus(slave);
+        bus.sendGetDLStatus(slave, [](DatagramState const& state){THROW_ERROR_DATAGRAM("Error fetching DL Status", state);});
         bus.finalizeDatagrams();
 
         printDLStatus(slave);

--- a/unit/bus-t.cc
+++ b/unit/bus-t.cc
@@ -620,7 +620,7 @@ TEST_F(BusTest, send_get_DL_status)
     checkSendFrame(Command::FPRD);
     handleReply<uint16_t>({0x0530});
 
-    bus.sendGetDLStatus(slave);
+    bus.sendGetDLStatus(slave, [](DatagramState const&){});
     ASSERT_EQ(slave.dl_status.PL_port0, 1);
     ASSERT_EQ(slave.dl_status.PL_port1, 1);
     ASSERT_EQ(slave.dl_status.PL_port2, 0);


### PR DESCRIPTION
DLStatus was put in the reg namespace, when it is actually a simple struct.
To prevent confusion and coherence, it is now treated like ALStatus.

To further assert the similarity of the objects, sendGetDLStatus now accepts an error callback, like sendGetALStatus