### PR TITLE
Add debug helpers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,3 +94,4 @@ if (GTest_FOUND)
 endif()
 
 add_subdirectory(examples)
+add_subdirectory(tools)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,7 @@ endif()
 
 if (GTest_FOUND)
   add_executable(kickcat_unit unit/bus-t.cc
+                              unit/debughelpers-t.cc
                               unit/diagnostics-t.cc
                               unit/frame-t.cc
                               unit/link-t.cc

--- a/include/kickcat/DebugHelpers.h
+++ b/include/kickcat/DebugHelpers.h
@@ -8,7 +8,7 @@ namespace kickcat
 {
 
     template<typename T>
-    void sendGetRegister(Link& link, uint16_t const& slave_address, uint16_t const& reg_address, T& value_read)
+    void sendGetRegister(Link& link, uint16_t slave_address, uint16_t reg_address, T& value_read)
     {
         auto process = [&value_read](DatagramHeader const*, uint8_t const* data, uint16_t wkc)
         {
@@ -30,13 +30,8 @@ namespace kickcat
         link.processDatagrams();
     }
 
-    void sendGetRegister(Link& link, uint16_t slave_address, uint16_t reg_address, uint16_t& value_read)
-    {
-        sendGetRegister<uint16_t>(link, slave_address, reg_address, value_read);
-    }
-
     template<typename T>
-    void sendWriteRegister(Link& link, uint16_t const& slave_address, uint16_t const& reg_address, T value_write)
+    void sendWriteRegister(Link& link, uint16_t slave_address, uint16_t reg_address, T value_write)
     {
         auto process = [&value_write](DatagramHeader const*, uint8_t const*, uint16_t wkc)
         {
@@ -54,11 +49,6 @@ namespace kickcat
 
         link.addDatagram(Command::FPWR, createAddress(slave_address, reg_address), value_write, process, error);
         link.processDatagrams();
-    }
-
-    void sendWriteRegister(Link& link, uint16_t const& slave_address, uint16_t const& reg_address, uint16_t const& value_write)
-    {
-        sendWriteRegister<uint16_t>(link, slave_address, reg_address, value_write);
     }
 }
 

--- a/include/kickcat/DebugHelpers.h
+++ b/include/kickcat/DebugHelpers.h
@@ -1,0 +1,65 @@
+#ifndef KICKCAT_DEBUGHELPERS_H
+#define KICKCAT_DEBUGHELPERS_H
+
+#include "Link.h"
+#include "Error.h"
+
+namespace kickcat
+{
+
+    template<typename T>
+    void sendGetRegister(Link& link, uint16_t const& slave_address, uint16_t const& reg_address, T& value_read)
+    {
+        auto process = [&value_read](DatagramHeader const*, uint8_t const* data, uint16_t wkc)
+        {
+            if (wkc != 1)
+            {
+                return DatagramState::INVALID_WKC;
+            }
+
+            value_read = *reinterpret_cast<T const*>(data);
+            return DatagramState::OK;
+        };
+
+        auto error = [](DatagramState const&)
+        {
+            THROW_ERROR("Error while trying to get slave register.");
+        };
+
+        link.addDatagram(Command::FPRD, createAddress(slave_address, reg_address), nullptr, process, error);
+        link.processDatagrams();
+    }
+
+    void sendGetRegister(Link& link, uint16_t slave_address, uint16_t reg_address, uint16_t& value_read)
+    {
+        sendGetRegister<uint16_t>(link, slave_address, reg_address, value_read);
+    }
+
+    template<typename T>
+    void sendWriteRegister(Link& link, uint16_t const& slave_address, uint16_t const& reg_address, T value_write)
+    {
+        auto process = [&value_write](DatagramHeader const*, uint8_t const*, uint16_t wkc)
+        {
+            if (wkc != 1)
+            {
+                return DatagramState::INVALID_WKC;
+            }
+            return DatagramState::OK;
+        };
+
+        auto error = [](DatagramState const&)
+        {
+            THROW_ERROR("Error while trying to set slave register.");
+        };
+
+        link.addDatagram(Command::FPWR, createAddress(slave_address, reg_address), value_write, process, error);
+        link.processDatagrams();
+    }
+
+    void sendWriteRegister(Link& link, uint16_t const& slave_address, uint16_t const& reg_address, uint16_t const& value_write)
+    {
+        sendWriteRegister<uint16_t>(link, slave_address, reg_address, value_write);
+    }
+}
+
+#endif

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,8 +1,15 @@
-set(EXAMPLE_SRCS scanTopology.cc)
-
-add_executable(scanTopology ${EXAMPLE_SRCS})
+add_executable(scanTopology scanTopology.cc)
 target_link_libraries(scanTopology kickcat)
 set_target_properties(scanTopology PROPERTIES
+    CXX_STANDARD 17
+    CXX_STANDARD_REQUIRED YES
+    CXX_EXTENSIONS NO
+    POSITION_INDEPENDENT_CODE ON
+)
+
+add_executable(debugUseCase debugUseCase.cc)
+target_link_libraries(debugUseCase kickcat)
+set_target_properties(debugUseCase PROPERTIES
     CXX_STANDARD 17
     CXX_STANDARD_REQUIRED YES
     CXX_EXTENSIONS NO

--- a/tools/debugUseCase.cc
+++ b/tools/debugUseCase.cc
@@ -1,0 +1,59 @@
+#include "kickcat/Link.h"
+#include "kickcat/protocol.h"
+#include "kickcat/DebugHelpers.h"
+#include "kickcat/SocketNull.h"
+
+#include <iostream>
+
+#ifdef __linux__
+    #include "kickcat/OS/Linux/Socket.h"
+#elif __PikeOS__
+    #include "kickcat/OS/PikeOS/Socket.h"
+#else
+    #error "Unknown platform"
+#endif
+
+
+using namespace kickcat;
+
+int main(int argc, char* argv[])
+{
+    std::shared_ptr<AbstractSocket> socketRedundancy;
+    std::string red_interface_name = "null";
+    std::string nom_interface_name = argv[1];
+
+    socketRedundancy = std::make_shared<SocketNull>();
+    auto socketNominal = std::make_shared<Socket>();
+    try
+    {
+        socketNominal->open(nom_interface_name, 2ms);
+        socketRedundancy->open(red_interface_name, 2ms);
+    }
+    catch (std::exception const& e)
+    {
+        std::cerr << e.what() << std::endl;
+        return 1;
+    }
+
+    auto reportRedundancy = []()
+    {
+        printf("Redundancy has been activated due to loss of a cable \n");
+    };
+
+    std::shared_ptr<Link> link= std::make_shared<Link>(socketNominal, socketRedundancy, reportRedundancy);
+    link->checkRedundancyNeeded();
+
+
+    // This register (0x800) has to be R/W on the device
+    sendWriteRegister<uint8_t>(*link, 0x00, 0x800, 0x0000);
+
+    uint16_t value_read;
+    sendGetRegister(*link, 0x00, 0x800, value_read);
+    printf("Value (initial) : %04x\n", value_read);
+
+    uint8_t value_write = 0x000f;
+    sendWriteRegister<uint8_t>(*link, 0x00, 0x800, value_write);
+
+    sendGetRegister(*link, 0x00, 0x800, value_read);
+    printf("Value (modified): %04x\n", value_read);
+}

--- a/tools/scanTopology.cc
+++ b/tools/scanTopology.cc
@@ -1,6 +1,7 @@
 #include "kickcat/Bus.h"
 #include "kickcat/Diagnostics.h"
 #include "kickcat/Prints.h"
+#include "kickcat/SocketNull.h"
 
 #ifdef __linux__
     #include "kickcat/OS/Linux/Socket.h"
@@ -18,14 +19,32 @@ using namespace kickcat;
 
 int main(int argc, char* argv[])
 {
-    if (argc != 2)
+    std::shared_ptr<AbstractSocket> socketRedundancy;
+    std::string red_interface_name = "null";
+    std::string nom_interface_name = argv[1];
+
+    socketRedundancy = std::make_shared<SocketNull>();
+    auto socketNominal = std::make_shared<Socket>();
+    try
     {
-        printf("usage: ./test NIC\n");
+        socketNominal->open(nom_interface_name, 2ms);
+        socketRedundancy->open(red_interface_name, 2ms);
+    }
+    catch (std::exception const& e)
+    {
+        std::cerr << e.what() << std::endl;
         return 1;
     }
 
-    auto socket = std::make_shared<Socket>();
-    Bus bus(socket);
+    auto reportRedundancy = []()
+    {
+        printf("Redundancy has been activated due to loss of a cable \n");
+    };
+
+    std::shared_ptr<Link> link= std::make_shared<Link>(socketNominal, socketRedundancy, reportRedundancy);
+    link->checkRedundancyNeeded();
+
+    Bus bus(link);
 
     auto print_current_state = [&]()
     {
@@ -39,7 +58,6 @@ int main(int argc, char* argv[])
     uint8_t io_buffer[2048];
     try
     {
-        socket->open(argv[1], 2ms);
         bus.init();
 
         print_current_state();
@@ -54,8 +72,6 @@ int main(int argc, char* argv[])
         std::cerr << e.what() << std::endl;
         return 1;
     }
-
-    socket->setTimeout(1ms);
 
     for (auto& slave : bus.slaves())
     {

--- a/unit/debughelpers-t.cc
+++ b/unit/debughelpers-t.cc
@@ -1,0 +1,53 @@
+#include <gtest/gtest.h>
+
+#include "Mocks.h"
+#include "kickcat/SocketNull.h"
+#include "kickcat/DebugHelpers.h"
+
+using namespace kickcat;
+
+TEST(DebugHelpers, sendGetRegister)
+{
+    std::shared_ptr<MockSocket> io_nominal{ std::make_shared<MockSocket>() };
+    std::shared_ptr<SocketNull> io_redundancy{ std::make_shared<SocketNull>() };
+    std::shared_ptr<Link> link = std::make_shared<Link>(io_nominal, io_redundancy, nullptr);
+    std::vector<DatagramCheck<uint8_t>> expected(1, {Command::FPRD, 0, false});
+
+    //Succesful read
+    uint16_t value_read = 1;
+    io_nominal->checkSendFrame(expected);
+    io_nominal->handleReply<uint16_t>({0xFF}, 1);
+    sendGetRegister(*link, 0x00, 0x110, value_read);
+    ASSERT_EQ(value_read, 0xFF);
+
+    //Invalid WKC
+    io_nominal->checkSendFrame(expected);
+    io_nominal->handleReply<uint16_t>({0xFF}, 2);
+    ASSERT_THROW(sendGetRegister(*link, 0x00, 0x110, value_read), Error);
+}
+
+TEST(DebugHelpers, sendWriteRegister)
+{
+    std::shared_ptr<MockSocket> io_nominal{ std::make_shared<MockSocket>() };
+    std::shared_ptr<SocketNull> io_redundancy{ std::make_shared<SocketNull>() };
+    std::shared_ptr<Link> link = std::make_shared<Link>(io_nominal, io_redundancy, nullptr);
+    std::vector<DatagramCheck<uint8_t>> expected(1, {Command::FPWR, 0, false});
+
+    // Succesful write
+    uint16_t value_write = 0x00;
+    io_nominal->checkSendFrame(expected);
+    io_nominal->handleReply<uint8_t>({0}, 1);
+    sendWriteRegister(*link, 0x00, 0x110, value_write);
+    ASSERT_EQ(value_write, 0);
+
+    //Invalid WKC
+    io_nominal->checkSendFrame(expected);
+    io_nominal->handleReply<uint16_t>({0xFF}, 2);
+    ASSERT_THROW(sendWriteRegister(*link, 0x00, 0x110, value_write), Error);
+
+    //Closed socket
+    io_nominal->close();
+    io_nominal->checkSendFrame(expected);
+    io_nominal->handleReply<uint16_t>({0xFF}, 2);
+    ASSERT_THROW(sendWriteRegister(*link, 0x00, 0x110, value_write), Error);
+}

--- a/unit/debughelpers-t.cc
+++ b/unit/debughelpers-t.cc
@@ -44,10 +44,4 @@ TEST(DebugHelpers, sendWriteRegister)
     io_nominal->checkSendFrame(expected);
     io_nominal->handleReply<uint16_t>({0xFF}, 2);
     ASSERT_THROW(sendWriteRegister(*link, 0x00, 0x110, value_write), Error);
-
-    //Closed socket
-    io_nominal->close();
-    io_nominal->checkSendFrame(expected);
-    io_nominal->handleReply<uint16_t>({0xFF}, 2);
-    ASSERT_THROW(sendWriteRegister(*link, 0x00, 0x110, value_write), Error);
 }


### PR DESCRIPTION
This MR proposes ready-to-use functions to read and write registers on an EtherCat device, used in an example.
Refer to device documentation to know whether a specific memory slot is available for R/W operations.