### PR TITLE
deactivate TX coalescing on linux

### DIFF
--- a/include/kickcat/OS/Linux/Socket.h
+++ b/include/kickcat/OS/Linux/Socket.h
@@ -8,7 +8,7 @@ namespace kickcat
     class Socket : public AbstractSocket
     {
     public:
-        Socket(nanoseconds rx_coalescing = -1us, nanoseconds polling_period = 20us);
+        Socket(nanoseconds coalescing = -1us, nanoseconds polling_period = 20us);
         virtual ~Socket()
         {
             close();
@@ -22,7 +22,7 @@ namespace kickcat
 
     private:
         int fd_{-1};
-        nanoseconds rx_coalescing_;
+        nanoseconds coalescing_;
         nanoseconds timeout_;
         nanoseconds polling_period_;
     };

--- a/src/OS/Linux/Socket.cc
+++ b/src/OS/Linux/Socket.cc
@@ -15,10 +15,10 @@
 
 namespace kickcat
 {
-    Socket::Socket(nanoseconds rx_coalescing, nanoseconds polling_period)
+    Socket::Socket(nanoseconds coalescing, nanoseconds polling_period)
         : AbstractSocket()
         , fd_{-1}
-        , rx_coalescing_{rx_coalescing}
+        , coalescing_{coalescing}
         , polling_period_(polling_period)
     {
 
@@ -79,7 +79,7 @@ namespace kickcat
         }
 
         // apply coalescing if asked
-        if (rx_coalescing_ >= 0us)
+        if (coalescing_ >= 0us)
         {
             struct ethtool_coalesce ecoal;
             ecoal.cmd = ETHTOOL_GCOALESCE;
@@ -92,7 +92,8 @@ namespace kickcat
             DEBUG_PRINT("old rx-usecs value %u\n", ecoal.rx_coalesce_usecs);
 
             ecoal.cmd = ETHTOOL_SCOALESCE;
-            ecoal.rx_coalesce_usecs = static_cast<unsigned int>(rx_coalescing_.count());
+            ecoal.rx_coalesce_usecs = static_cast<unsigned int>(coalescing_.count());
+            ecoal.tx_coalesce_usecs = static_cast<unsigned int>(coalescing_.count());
             rc = ioctl(fd_, SIOCETHTOOL, &ifr);
             if (rc < 0)
             {


### PR DESCRIPTION
close #82 

Tested on 3 mainboards, no latency change on the first two. On the third board, the time of flight of the 1368 bytes frames dropped from 430 µs to 159µs.