### PR TITLE
Use an alias for since_epoch default implementation

### DIFF
--- a/include/kickcat/Time.h
+++ b/include/kickcat/Time.h
@@ -11,7 +11,7 @@ namespace kickcat
     void sleep(nanoseconds ns);
 
     // return the time in ns since epoch
-    nanoseconds since_epoch() __attribute__((weak));
+    nanoseconds since_epoch();
 
     nanoseconds elapsed_time(nanoseconds start = since_epoch());
 }

--- a/src/Slave.cc
+++ b/src/Slave.cc
@@ -174,7 +174,7 @@ namespace kickcat
         return sum;
     }
 
-    int Slave::countOpenPorts() 
+    int Slave::countOpenPorts()
     {
         return  dl_status.PL_port0 +
                 dl_status.PL_port1 +

--- a/src/Time.cc
+++ b/src/Time.cc
@@ -1,18 +1,17 @@
-#include <ctime>
-#include <cstdio>
-#include <cerrno>
-/// \brief OS agnostic time API implementation
-
+// \brief OS agnostic time API implementation
 #include "Time.h"
 
 namespace kickcat
 {
-    nanoseconds since_epoch()
+    extern "C"
     {
-        auto now = time_point_cast<nanoseconds>(system_clock::now());
-        return now.time_since_epoch();
+        static nanoseconds __since_epoch()
+        {
+            auto now = time_point_cast<nanoseconds>(system_clock::now());
+            return now.time_since_epoch();
+        }
     }
-
+    __attribute__((weak,alias("__since_epoch"))) nanoseconds since_epoch();
 
     nanoseconds elapsed_time(nanoseconds start)
     {

--- a/unit/Mocks.h
+++ b/unit/Mocks.h
@@ -133,8 +133,4 @@ namespace kickcat
 
         uint16_t nextIndex() { AbstractDiagSocket::nextIndex(); return index_; }
     };
-
-
-    nanoseconds timeIncrement();
-    void setTimeIncrement(nanoseconds increment);
 }


### PR DESCRIPTION
Use a weak alias to define the default implementation of since_epoch() instead of a direct weak symbol declaration.

close #84 