### PR TITLE
update cmake min required for conan CI pipeline

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16.3)
+cmake_minimum_required(VERSION 3.15)
 project(KickCAT)
 
 # Custom CMake modules


### PR DESCRIPTION
Update cmake min required as the cmake version in the conan-io CI is cmake version 3.15