### PR TITLE
Shorten path for debug and error traces

### DIFF
--- a/include/kickcat/Error.h
+++ b/include/kickcat/Error.h
@@ -8,17 +8,34 @@
 
 namespace kickcat
 {
+    constexpr const char* strip_path(const char* path)
+    {
+        const char* file = path;
+        while (*path)
+        {
+            if (*path++ == '/')
+            {
+                file = path;
+            }
+            if (*path == ':')
+            {
+                break;
+            }
+        }
+        return file;
+    }
+
     #define STR1(x) #x
     #define STR2(x) STR1(x)
-    #define LOCATION __FILE__ ":" STR2(__LINE__)
-    #define THROW_ERROR(msg)                    (throw kickcat::Error{LOCATION ": " msg})
-    #define THROW_ERROR_CODE(msg, code)         (throw kickcat::ErrorCode{LOCATION ": " msg, static_cast<int32_t>(code)})
-    #define THROW_ERROR_DATAGRAM(msg, state)    (throw kickcat::ErrorDatagram{LOCATION ": " msg, state})
-    #define THROW_SYSTEM_ERROR_CODE(msg, code)  (throw std::system_error(code, std::generic_category(), LOCATION ": " msg))
+    #define LOCATION(suffix) strip_path(__FILE__ ":" STR2(__LINE__) suffix)
+    #define THROW_ERROR(msg)                    (throw kickcat::Error{LOCATION(": " msg)})
+    #define THROW_ERROR_CODE(msg, code)         (throw kickcat::ErrorCode{LOCATION(": " msg), static_cast<int32_t>(code)})
+    #define THROW_ERROR_DATAGRAM(msg, state)    (throw kickcat::ErrorDatagram{LOCATION(": " msg), state})
+    #define THROW_SYSTEM_ERROR_CODE(msg, code)  (throw std::system_error(code, std::generic_category(), LOCATION(": " msg)))
     #define THROW_SYSTEM_ERROR(msg)             THROW_SYSTEM_ERROR_CODE(msg, errno)
 
 #ifdef DEBUG
-    #define DEBUG_PRINT(...) do { fprintf(stderr, "DEBUG: %s:%d: ", __FILE__, __LINE__); fprintf(stderr, ##__VA_ARGS__); } while(0);
+    #define DEBUG_PRINT(...) do { fprintf(stderr, "DEBUG: %s ", LOCATION()); fprintf(stderr, ##__VA_ARGS__); } while(0);
 #else
     #define DEBUG_PRINT(...)
 #endif

--- a/src/OS/Linux/Socket.cc
+++ b/src/OS/Linux/Socket.cc
@@ -135,7 +135,7 @@ namespace kickcat
         int rc = ::close(fd_);
         if (rc < 0)
         {
-            perror(LOCATION ": close()"); // we cannot throw here - at least trace the error
+            perror(LOCATION(": close()")); // we cannot throw here - at least trace the error
         }
         fd_ = -1;
     }

--- a/src/OS/Linux/UdpDiagSocket.cc
+++ b/src/OS/Linux/UdpDiagSocket.cc
@@ -44,7 +44,7 @@ namespace kickcat
         int rc = ::close(fd_);
         if (rc < 0)
         {
-            perror(LOCATION ": close()"); // we cannot throw here - at least trace the error
+            perror(LOCATION(": close()")); // we cannot throw here - at least trace the error
         }
         fd_ = -1;
     }


### PR DESCRIPTION
Previous display:

```
DEBUG: /home/theo/wdc_workspace/src/KickCAT/src/Frame.cc:221: read() failed
DEBUG: /home/theo/wdc_workspace/src/KickCAT/src/Link.cc:263: redundancy read fail
/home/theo/wdc_workspace/src/KickCAT/examples/easycat/easycat_example.cc:112: something bad happened at 2534 delta: 1
```


New display:

```
DEBUG: Frame.cc:221 read() failed
DEBUG: Link.cc:263 redundancy read fail
easycat_example.cc:112: something bad happened at 14601 delta: 1
```